### PR TITLE
Assign transaction_id and pid to WsCursor

### DIFF
--- a/ws_transactions.py
+++ b/ws_transactions.py
@@ -174,7 +174,7 @@ class WSTransactionService(netsvc.Service):
         try:
             self.log(netsvc.LOG_DEBUG,
                 'Executing from transaction ID: %s TID: %s PID: %s'
-                % (transaction_id, cursor.psql_tid, cursor.psql_pid)
+                % (transaction_id, sync_cursor.psql_tid, sync_cursor.psql_pid)
             )
             res = pool.execute_cr(cursor, uid, obj, method, *args, **kw)
         except Exception, exc:


### PR DESCRIPTION
Get `txid_current()`  and `pg_backend_pid` to show in logs to track then in postgresql.log
