### PR TITLE
Fixing behaviour on errors (see details)

### DIFF
--- a/ws_transactions.py
+++ b/ws_transactions.py
@@ -101,6 +101,7 @@ class WSTransactionService(netsvc.Service):
         self.exportMethod(self.rollback)
         self.exportMethod(self.commit)
         self.exportMethod(self.close)
+        self.exportMethod(self.close_connection)
         self.exportMethod(self.list)
         self.exportMethod(self.kill)
         self.log(netsvc.LOG_INFO, 'Ready for webservices transactions...')
@@ -243,5 +244,9 @@ class WSTransactionService(netsvc.Service):
         res = sync_cursor.close()
         del self.cursors[uid][transaction_id]
         return res
+
+    def close_connection(self, dbname, uid, passwd, transaction_id):
+        """Alias for close"""
+        self.close(dbname, uid, passwd, transaction_id)
 
 WSTransactionService()

--- a/ws_transactions.py
+++ b/ws_transactions.py
@@ -201,8 +201,12 @@ class WSTransactionService(netsvc.Service):
             )
             res = pool.execute_cr(cursor, uid, obj, method, *args, **kw)
         except Exception, exc:
-            self.rollback(dbname, uid, passwd, transaction_id)
-            raise exc
+            #self.rollback(dbname, uid, passwd, transaction_id)
+            import traceback
+            self.log(netsvc.LOG_ERROR,
+                'Error within a transaction:\n'+
+                traceback.format_exc())
+            raise
         return res
 
     def rollback(self, dbname, uid, passwd, transaction_id):


### PR DESCRIPTION
- rollback after a failed transaction always fail, so don't
- log the exception traceback, no more silent errors
- no-argument raise (instead "raise e") keeps the stack